### PR TITLE
Added Bower configuration file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "diff-dom",
+  "main": "diffDOM.js",
+  "version": "0.0.1",
+  "homepage": "https://github.com/fiduswriter/diffDOM",
+  "authors": [
+    "Johannes Wilm <mail@johanneswilm.org>"
+  ],
+  "description": "A diff for DOM elements, as client-side JavaScript code. Gets all modifications, insertions and removals between two DOM fragments.",
+  "license": "LGPL",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I've added the Bower configuration file, but to actually register the module with Bower (`sudo npm install bower -g`), you'll need to issue the following command: `bower register diff-dom https://github.com/fiduswriter/diffDOM`.

I could do it myself, but then I'd have control over the module in Bower, and not you :-1: