### PR TITLE
Improved diff size by passing context data to roughlyEqual()

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ This project is licensed under the LGPL v. 3. For details see <a href="LICENSE.t
 
 <h2>Tests</h2>
 
-<p>There is a <a href="tests/random.html">test of random elements</a>, one of <a href="tests/basic.html">basic elements</a>, and of <a href="tests/form.html">form elements</a> that tended to throw errors in previous versions of this library.</p>
+<p>There is a <a href="tests/random.html">test of random elements</a>, one of <a href="tests/basic.html">basic elements</a>, one that <a href="tests/extent.html">tests the extents of diffs</a> to help generate the least number of changes, and of <a href="tests/form.html">form elements</a> that tended to throw errors in previous versions of this library.</p>
 
 <h2>Demo</h2>
 

--- a/tests/extent.html
+++ b/tests/extent.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>diffDOM</title>
+  <style>
+    .success {
+      background-color: LightGreen;
+    }
+    .failure {
+      background-color: Tomato;
+    }
+  </style>
+  <script src="TraceLogger.js">
+  </script>
+  <script src="../diffDOM.js">
+  </script>
+</head>
+
+<body>
+
+  <h1>Extent Test for diffDOM</h1>
+
+  <!-- Add all divs to be compared here two by two -->
+
+
+  <div>
+    <span class="subclass">
+      <h2>Test</h2>
+    </span>
+  </div>
+  <div>
+    <span class="subclass">
+      <h2>Different</h2>
+      <p>Added!</p>
+    </span>
+  </div>
+
+  <div>
+    <h2>this is a paragraph `ha`&nbsp;</h2>
+    <ul><li>some stuff</li></ul>
+  </div>
+  <div>
+    <h2 class="foo">this is another <code>ha</code>&nbsp;</h2>
+    <ul><li>some stuff</li></ul>
+  </div>
+
+  <div>
+    <h2>this is a paragraph <code>ha</code>&nbsp;</h2>
+    <h2>this is another`h`&nbsp;</h2>
+    <ul><li>some stuff</li></ul>
+  </div>
+  <div>
+    <h2>this is a paragraph <code>ha</code>&nbsp;</h2>
+    <h2>this is another<code>h</code>&nbsp;</h2>
+    <ul><li>some stuff</li></ul>
+  </div>
+
+  <div>
+    <span>
+      <h2>Different</h2>
+      <p>Added!</p>
+      <p>Woah!</p>
+    </span>
+  </div>
+
+  <div>
+    <span>
+      <h2>Different</h2>
+      <p>Added!</p>
+      <p>Crazy!</p>
+      <p>Another!</p>
+    </span>
+  </div>
+
+
+
+
+
+  <script>
+    function reportDiv() {
+      document.body.appendChild(document.createElement('div'));
+    }
+
+    function testSuccess() {
+      document.body.lastChild.classList.add('success');
+    }
+
+    function testFailure() {
+      document.body.lastChild.classList.add('failure');
+    }
+
+    function print(text) {
+      var par = document.createElement('p');
+      par.textContent = text;
+      document.body.lastChild.appendChild(par);
+    }
+
+    function countChildNodes(nodes) {
+      var num = 0;
+      num += nodes.length;
+      for (var i = 0; i < nodes.length; i++) {
+        var node = nodes[i];
+        if (node.childNodes) {
+          num += countChildNodes(node.childNodes);
+        }
+      }
+      return num;
+    }
+
+    function size(diffs) {
+      var cost = 0;
+      for (var i=0; i < diffs.length; i++) {
+        var diff = diffs[i];
+        cost += 1;
+        if (diff.element && diff.element.childNodes) {
+          cost += countChildNodes(diff.element.childNodes);
+        }
+      }
+      return cost;
+    }
+
+    var dd = new diffDOM(true, 500),
+      tl = new TraceLogger(dd),
+      divNodeList, divs = [],
+      diffs, t1, i;
+
+    divNodeList = document.querySelectorAll('div');
+
+    for (i = 0; i < divNodeList.length; i++) {
+      divs[i] = divNodeList[i];
+      divs[i].parentNode.removeChild(divs[i]);
+    }
+
+
+    for (i = 0; i < divs.length; i = i + 2) {
+
+
+      try {
+        reportDiv();
+        print("diff operations for div #" + i + " → div #" + (i + 1));
+        diffs = dd.diff(divs[i + 1], divs[i]);
+        console.log(diffs);
+
+        print(diffs.length + ' diffs affecting ' + size(diffs) + ' elements in ' + JSON.stringify(diffs).length + ' bytes');
+
+        print("applying...");
+        t1 = divs[i + 1].cloneNode(true);
+        dd.apply(t1, diffs);
+
+        if (t1.innerHTML === divs[i].innerHTML) {
+          print('...success!');
+        } else {
+          testFailure();
+          console.log(diffs);
+          console.log(t1.outerHTML);
+          console.log(divs[i].outerHTML);
+          throw 'Outputs not matching';
+        }
+
+        print("undoing...");
+        dd.undo(t1, diffs);
+
+        if (t1.innerHTML === divs[i + 1].innerHTML) {
+          print('...success!');
+          testSuccess();
+        } else {
+          testFailure();
+          console.log(diffs);
+          console.log(t1.outerHTML);
+          console.log(divs[i + 1].outerHTML);
+          throw 'Outputs not matching';
+        }
+        //try {
+      } catch (e) {
+        console.log("error occured\n", e.toString());
+        console.log(tl.toString());
+        throw e;
+      }
+    }
+  </script>
+
+</body>
+
+</html>


### PR DESCRIPTION
Adds a technique derived from the Patience Diff algorithm, http://bramcohen.livejournal.com/73318.html. When comparing subtrees, look for unique elements and consider them the same, even if they have a different number of children. This is implemented by generating valid CSS-like selectors for each tag and discarding any that occur exclusively in one tree, or that occur more than once in any tree.

The effect this has is that if we have a single div in both trees, but one 3 children and one has 5, we don't want to remove one and add the other, but instead diff the contents of each.

Similarly, if we have an input common to both trees that has an id set, we can be sure that we'd rather add a p tag before it rather than remove the input and create a new one that looks the same. This is especially true for inputs since removing and re-adding a form element can cause the element to lose focus.

A new test page was added that shows the number of affected elements and rough diff size. Running this test with 1.0.0 and this version should show a generally big improvement for the example divs.

For situations where the current subtree has the same number of elements with the same tag names and classes/ids, we also consider such elements for child diffing instead of wholesale remove/add.