### PR TITLE
added options to limit how deep level of the DOM tree should be diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,10 @@ dd = new diffDOM({
     valueDiffing: false
   });
 ```
+
+#### Limit how deep level of the DOM tree should be diff for large size of HTML code
+```
+diff = dd.diff(elementA, elementB,{
+      levelsDeep: 3
+    });
+```

--- a/diffDOM.js
+++ b/diffDOM.js
@@ -437,6 +437,18 @@
         }(obj[p1]));
     }
 
+    function getLevelsDeep(node){
+        var deep = 0;
+        if(node.nodeType === 1){
+            var pn = node;
+            do{
+                pn = pn.parentNode;
+                deep++;
+            }while(pn);
+        }
+
+        return deep;
+    }
 
     var DiffTracker = function() {
         this.list = [];
@@ -520,7 +532,7 @@
 
         // ===== Create a diff =====
 
-        diff: function(t1, t2) {
+        diff: function(t1, t2, options) {
             diffcount = 0;
             t1 = cleanCloneNode(t1);
             t2 = cleanCloneNode(t2);
@@ -529,6 +541,7 @@
                 this.t2Orig = nodeToObj(t2);
             }
 
+            this.diffOptions = options || {};
             this.tracker = new DiffTracker();
             return this.findDiffs(t1, t2);
         },
@@ -659,6 +672,10 @@
                 if (t1.innerHTML === t2.innerHTML) {
                     return [];
                 }
+            }
+
+            if(!!this.diffOptions.levelsDeep && this.diffOptions.levelsDeep < getLevelsDeep(t1)){
+                return [];
             }
 
             var subtrees = markSubTrees(t1, t2),

--- a/diffDOM.js
+++ b/diffDOM.js
@@ -440,11 +440,8 @@
     function getLevelsDeep(node){
         var deep = 0;
         if(node.nodeType === 1){
-            var pn = node;
-            do{
-                pn = pn.parentNode;
-                deep++;
-            }while(pn);
+            deep = node.parentNode?node.parentNode.levelsDeep:deep;
+            node.levelsDeep = ++deep;
         }
 
         return deep;


### PR DESCRIPTION
I've read the whole source codes,my first idea is use linked list instead of array,because DOM tree actually is a doubly linked lists,but it's too tough to get started,not sure if it's the right way to go,I guess I am just not ready for this.
So I tried the DOM level first,it helps a lot when my DOM tree is too large and too deep and it's not worth to diff them all.
I can't find a better way to get rid of the while loop when count the DOM levels,do you have a better idea?
My next step is try to add a selector filter,which maybe more custom-able,because the levels way is too wide range.

