### PR TITLE
diff hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,41 @@ dd = new diffDOM({
   });
 ```
 
+#### Pre and post diff hooks
+
+diffDOM provides extension points before and after virtual and actual diffs, exposing some of the internals of the diff algorithm, and allowing you to make additional decisions based on that information.
+
+```
+dd = new diffDOM({
+    preVirtualDiffApply: function (info) {
+        console.log(info);
+    },
+    postVirtualDiffApply: function (info) {
+        console.log(info);
+    },
+    preDiffApply: function (info) {
+        console.log(info);
+    },
+    postDiffApply: function (info) {
+        console.log(info);
+    }
+  });
+```
+
+Additionally, the _pre_ hooks allow you to shortcircuit the standard behaviour of the diff by returning 'true' from this callback. This will cause the diffApply functions to return prematurely, skipping their standard behaviour.
+
+```
+dd = new diffDOM({
+    // prevent removal of attributes
+    preDiffApply: function (info) {
+        if (info.diff.action === 'removeAttribute') {
+            console.log("preventing attribute removal");
+            return true;
+        }
+    }
+  });
+```
+
 #### Debugging
 
 For debugging you might want to set a max number of diff changes between two elements before diffDOM gives up. To allow for a maximum of 500 differences between elements when diffing, initialize diffDOM like this:

--- a/diffDOM.js
+++ b/diffDOM.js
@@ -438,7 +438,13 @@
                 textDiff: function() {
                     arguments[0].data = arguments[3];
                     return;
-                }
+                },
+                // empty functions were benchmarked as running faster than both
+                // `f && f()` and `if (f) { f(); }`
+                preVirtualDiffApply: function () {},
+                postVirtualDiffApply: function () {},
+                preDiffApply: function () {},
+                postDiffApply: function () {}
             },
             i;
 
@@ -971,6 +977,14 @@
                 nodeIndex = routeInfo.nodeIndex,
                 newNode, route, c;
 
+            // pre-diff hook
+            var info = {
+                diff: diff,
+                node: node
+            };
+
+            this.preVirtualDiffApply(info);
+
             switch (diff.action) {
                 case 'addAttribute':
                     if (!node.attributes) {
@@ -1095,6 +1109,10 @@
                     console.log('unknown action');
             }
 
+            // capture newNode for the callback
+            info.newNode = newNode;
+            this.postVirtualDiffApply(info);
+
             return;
         },
 
@@ -1131,6 +1149,14 @@
         applyDiff: function(tree, diff) {
             var node = this.getFromRoute(tree, diff.route),
                 newNode, reference, route, c;
+
+            // pre-diff hook
+            var info = {
+                diff: diff,
+                node: node
+            };
+
+            this.preDiffApply(info);
 
             switch (diff.action) {
                 case 'addAttribute':
@@ -1222,6 +1248,10 @@
                 default:
                     console.log('unknown action');
             }
+
+            // if a new node was created, we might be interested in it
+            info.newNode = newNode;
+            this.postDiffApply(info);
 
             return true;
         },

--- a/diffDOM.js
+++ b/diffDOM.js
@@ -983,7 +983,7 @@
                 node: node
             };
 
-            this.preVirtualDiffApply(info);
+            if (this.preVirtualDiffApply(info)) { return true; }
 
             switch (diff.action) {
                 case 'addAttribute':
@@ -1156,7 +1156,7 @@
                 node: node
             };
 
-            this.preDiffApply(info);
+            if (this.preDiffApply(info)) { return true; }
 
             switch (diff.action) {
                 case 'addAttribute':
@@ -1250,6 +1250,7 @@
             }
 
             // if a new node was created, we might be interested in it
+            // post diff hook
             info.newNode = newNode;
             this.postDiffApply(info);
 

--- a/diffDOM.js
+++ b/diffDOM.js
@@ -448,12 +448,12 @@
             },
             i;
 
-        if (typeof options == "undefined") {
+        if (typeof options === "undefined") {
             options = {};
         }
 
         for (i in defaults) {
-            if (typeof options[i] == "undefined") {
+            if (typeof options[i] === "undefined") {
                 this[i] = defaults[i];
             } else {
                 this[i] = options[i];


### PR DESCRIPTION
These patches add hooks which are executed before and after the application of virtual and actual diffs, taking information about the diffs as arguments.

Returning a truthy value from the callback causes the rest of that particular diff application to shortcircuit, otherwise behaviour proceeds as normally.

README.md provides examples.