### PR TITLE
Hook filterOuterDiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,23 @@ dd = new diffDOM({
   });
 ```
 
+#### Outer and Inner diff hooks
+
+diffDOM also provides a way to filter outer diff
+
+```
+dd = new diffDOM({
+    filterOuterDiff: function(t1, t2, diffs) {
+        // can change current outer diffs by returning a new array,
+        // or by mutating outerDiffs.
+        if (!diffs.length && t1.nodeName == "my-component" && t2.nodeName == t1.nodeName) {
+            // will not diff childNodes
+            t1.innerDone = true;
+        }
+    }
+});
+```
+
 #### Debugging
 
 For debugging you might want to set a max number of diff changes between two elements before diffDOM gives up. To allow for a maximum of 500 differences between elements when diffing, initialize diffDOM like this:

--- a/diffDOM.js
+++ b/diffDOM.js
@@ -444,7 +444,8 @@
                 preVirtualDiffApply: function () {},
                 postVirtualDiffApply: function () {},
                 preDiffApply: function () {},
-                postDiffApply: function () {}
+                postDiffApply: function () {},
+                filterOuterDiff: null
             },
             i;
 
@@ -512,7 +513,7 @@
             return this.tracker.list;
         },
         findNextDiff: function(t1, t2, route) {
-            var diffs;
+            var diffs, fdiffs;
 
             if (this.maxDepth && route.length > this.maxDepth) {
                 return [];
@@ -520,6 +521,10 @@
             // outer differences?
             if (!t1.outerDone) {
                 diffs = this.findOuterDiff(t1, t2, route);
+                if (this.filterOuterDiff) {
+                    fdiffs = this.filterOuterDiff(t1, t2, diffs);
+                    if (fdiffs) diffs = fdiffs;
+                }
                 if (diffs.length > 0) {
                     t1.outerDone = true;
                     return diffs;

--- a/diffDOM.js
+++ b/diffDOM.js
@@ -461,6 +461,9 @@
         }
 
     };
+
+    diffDOM.Diff = Diff;
+
     diffDOM.prototype = {
 
         // ===== Create a diff =====


### PR DESCRIPTION
Example of what i'm doing with it:
```
var diffd;
function morph(from, to) {
	if (!diffd) diffd = new diffDOM({
		filterOuterDiff: function(from, to, diffs) {
			if (/^component-/i.test(from.nodeName) && !diffs.length) {
				from.innerDone = true;
			}
		}
	});
	diffd.apply(from, diffd.diff(from, to));
}
```
this allows to ignore inner nodes of custom elements, when no shadow dom allows me to make it completely transparent.