### PR TITLE
Fixing textarea value changes not showing

### DIFF
--- a/diffDOM.js
+++ b/diffDOM.js
@@ -707,7 +707,9 @@
                         objNode.attributes[attribute.name] = attribute.value;
                     }
                 }
-                if (aNode.childNodes && aNode.childNodes.length > 0) {
+                if (objNode.nodeName === 'TEXTAREA') {
+                    objNode.value = aNode.value;
+                } else if (aNode.childNodes && aNode.childNodes.length > 0) {
                     objNode.childNodes = [];
                     nodeArray = Array.prototype.slice.call(aNode.childNodes);
                     length = nodeArray.length;
@@ -1110,10 +1112,6 @@
                     break;
                 case this._const.modifyTextElement:
                     node.data = diff[this._const.newValue];
-
-                    if (parentNode.nodeName === 'TEXTAREA') {
-                        parentNode.value = diff[this._const.newValue];
-                    }
                     break;
                 case this._const.modifyValue:
                     node.value = diff[this._const.newValue];

--- a/tests/form.html
+++ b/tests/form.html
@@ -171,7 +171,7 @@
       console.log(theDiff);
     }
 
-    second.innerHTML = 'Some text';
+    second.value = 'Some text';
 
     reportDiv();
 

--- a/tests/form.html
+++ b/tests/form.html
@@ -199,6 +199,28 @@
       console.log(theDiff);
     }
 
+    reportDiv();
+
+    second.innerText = 'Some text';
+    third.innerText = 'Some other text';
+
+    reportDivDescription(first, second);
+
+    theDiff = dd.diff(first, second);
+
+    dd.apply(first, theDiff);
+
+    theDiff = dd.diff(first, third);
+
+    dd.apply(first, theDiff);
+
+    if (first.value === third.value) {
+      success(theDiff);
+    } else {
+      testFailure();
+      console.log(theDiff);
+    }
+
     // Input type = text
 
     setSection('Input type = text');

--- a/tests/form.html
+++ b/tests/form.html
@@ -171,7 +171,7 @@
       console.log(theDiff);
     }
 
-    second.value = 'Some text';
+    second.innerHTML = 'Some text';
 
     reportDiv();
 
@@ -192,7 +192,7 @@
 
     theDiff = dd.diff(first, second);
 
-    if (theDiff.length === 2) {
+    if (theDiff.length === 1) {
       success(theDiff);
     } else {
       testFailure();


### PR DESCRIPTION
For a textarea value change to be displayed the value attribute must be updated, however textarea elements do not have a "value" entry in their attributes NamedNodeMap. This change ensures the value attribute is always considered for textarea elements.