### PR TITLE
Make sure nodes are not replaced due to case sensitivity

### DIFF
--- a/diffDOM.js
+++ b/diffDOM.js
@@ -713,7 +713,7 @@
             var objNode = {},
                 dobj = this,
                 nodeArray, childNode, length, attribute, i;
-            objNode.nodeName = aNode.nodeName;
+            objNode.nodeName = aNode.nodeName.toLowerCase();
             if (objNode.nodeName === '#text' || objNode.nodeName === '#comment') {
                 objNode.data = aNode.data;
             } else {

--- a/diffDOM.js
+++ b/diffDOM.js
@@ -713,7 +713,9 @@
             var objNode = {},
                 dobj = this,
                 nodeArray, childNode, length, attribute, i;
-            objNode.nodeName = aNode.nodeName.toLowerCase();
+            objNode.nodeName = aNode.nodeName;
+            if (objNode.nodeName && objNode.nodeName.indexOf("#") != 0)
+                objNode.nodeName = objNode.nodeName.toUpperCase();
             if (objNode.nodeName === '#text' || objNode.nodeName === '#comment') {
                 objNode.data = aNode.data;
             } else {


### PR DESCRIPTION
I found an issue when nodeName's are same (say HTML and html) but due to case sensitivity, it will trigger replaceElement.

In HTML DOM elements, nodeName are always upper case. however if a DOM is created via XML, it does return lower case for nodeName.