### PR TITLE
Shorthand of object was breaking in IE 11

### DIFF
--- a/src/diffDOM/virtual/diff.js
+++ b/src/diffDOM/virtual/diff.js
@@ -45,8 +45,8 @@ export class DiffFinder {
                     if (this.foundAll) {
                         console.error('Could not find remaining diffs!')
                         console.log({
-                            t1,
-                            t2
+                            't1': t1,
+                            't2': t2
                         })
                     } else {
                         this.foundAll = true


### PR DESCRIPTION
This issue was causing Diff Dom to continuously loop in IE 11