### PR TITLE
move dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,16 +28,14 @@
         "diff",
         "dom"
     ],
-    "dependencies": {
-        "rollup-plugin-terser": "^5.1.1",
-        "updates": "^8.5.2"
-    },
     "devDependencies": {
         "@babel/preset-env": "^7.5.5",
         "eslint": "^6.2.1",
         "jest": "^24.9.0",
-        "rollup": "^1.19.4",
         "rollup-plugin-buble": "^0.19.8",
-        "slimdom": "^2.3.1"
+        "rollup-plugin-terser": "^5.1.1",
+        "rollup": "^1.19.4",
+        "slimdom": "^2.3.1",
+        "updates": "^8.5.2"
     }
 }


### PR DESCRIPTION
"updates" and "rollup-plugin-terser" only seem to be used during the development of this project. They don't need to pulled in by dependant projects for diffDOM to function.

I came across this because [synk is reporting a vulnerability in a project I maintain](https://snyk.io/test/npm/@agiledigital/mule-preview/2.1.0) due to a transitive dependency of the "updates" package but as far as I can see it is not needed.

Thanks for publishing such a useful library!

![image](https://user-images.githubusercontent.com/2357137/66563927-8f244f80-ebaa-11e9-9b4d-3d888a80bd7f.png)
