### PR TITLE
Fix nodeToObj failure scenario when using DOMParser().parseFromString

### DIFF
--- a/src/diffDOM/helpers.ts
+++ b/src/diffDOM/helpers.ts
@@ -28,13 +28,10 @@ export function checkElementType(element, ...elementTypeNames: string[]) {
     if (typeof element === "undefined" || element === null) {
         return false
     }
-    return elementTypeNames.some(
-        (elementTypeName) =>
-            // We need to check if the specified type is defined
-            // because otherwise instanceof throws an exception.
-            typeof element?.ownerDocument?.defaultView?.[elementTypeName] ===
-                "function" &&
-            element instanceof
-                element.ownerDocument.defaultView[elementTypeName],
-    )
+    return elementTypeNames.some((elementTypeName) => {
+        const typeIsDefined = typeof window[elementTypeName] === "function"
+        const elementIsThisType = element instanceof window[elementTypeName]
+
+        return typeIsDefined && elementIsThisType
+    })
 }

--- a/tests/toObj.test.js
+++ b/tests/toObj.test.js
@@ -35,14 +35,13 @@ describe("parsing", () => {
             htmlDocument.body.childNodes[1].childNodes[1].childNodes[1]
                 .textContent
 
-        console.log(h1TextContentInParsedDocument)
+        // Sanity check: Ensure the text we want to check actually exists
+        expect(h1TextContentInParsedDocument).toEqual(h1TextContent)
 
         const documentObject = nodeToObj(htmlDocument.body)
         const h1Object =
             documentObject.childNodes[1].childNodes[1].childNodes[1]
                 .childNodes[0]
-
-        console.log(h1Object)
 
         expect(h1Object.data).toEqual(h1TextContent)
     })

--- a/tests/toObj.test.js
+++ b/tests/toObj.test.js
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { nodeToObj } from "../dist/index"
+
+const h1TextContent = "Section"
+
+const htmlString = `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Node To Obj Test</title>
+  </head>
+
+  <body>
+    <div>
+      <main>
+        <h1>${h1TextContent}</h1>
+        <h3>more stuff</h3>
+      </main>
+    </div>
+  </body>
+</html>
+`
+
+describe("parsing", () => {
+    it("Can parse obj correctly", () => {
+        const htmlDocument = new DOMParser().parseFromString(
+            htmlString,
+            "text/html",
+        )
+
+        const h1TextContentInParsedDocument =
+            htmlDocument.body.childNodes[1].childNodes[1].childNodes[1]
+                .textContent
+
+        console.log(h1TextContentInParsedDocument)
+
+        const documentObject = nodeToObj(htmlDocument.body)
+        const h1Object =
+            documentObject.childNodes[1].childNodes[1].childNodes[1]
+                .childNodes[0]
+
+        console.log(h1Object)
+
+        expect(h1Object.data).toEqual(h1TextContent)
+    })
+})


### PR DESCRIPTION
Fixes https://github.com/fiduswriter/diffDOM/issues/144

-------------

Problem: When using nodeToObj with a Document that was created using
`new DOMParser().parseFromString`, text nodes wouldn't be registered
and the whole thing is completely wrong.

The resulting document had no "defaultView", i.e., it had no window,
which means types wouldn't be defined, even though they exist.

Switching to checking for `window` directly sidesteps the issue,
and all current tests pass.

https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView

> In browsers, document.defaultView returns the window object
 associated with a document, or null if none is available.