### PR TITLE
fix: update regex for attribute parsing to improve accuracy

### DIFF
--- a/src/diffDOM/virtual/fromString.ts
+++ b/src/diffDOM/virtual/fromString.ts
@@ -5,7 +5,7 @@ import { DiffDOMOptionsPartial, nodeType } from "../types"
 const tagRE =
     /<\s*\/*[a-zA-Z:_][a-zA-Z0-9:_\-.]*\s*(?:"[^"]*"['"]*|'[^']*'['"]*|[^'"/>])*\/*\s*>|<!--(?:.|\n|\r)*?-->/g
 
-const attrRE = /\s([^'"/\s><]+?)[\s/>]|([^\s=]+)=\s?(".*?"|'.*?')/g
+const attrRE = /\s([^'"/\s><]+?)[\s/>]|([^\s=]+)=\s?("[^"]*"|'[^']*')/g
 
 function unescape(string: string) {
     return string


### PR DESCRIPTION
Fixed #147 

Update the regex used for string recognition to tolerate new lines in attribute values. Otherwise, this can be used for script injection into the page.